### PR TITLE
fix: scrollbar styling and corner-bottom-radius of anime card

### DIFF
--- a/src/components/Anime/Anime.jsx
+++ b/src/components/Anime/Anime.jsx
@@ -54,7 +54,7 @@ function Anime() {
   }, [pageNo]);
 
   return (
-    <div>
+    <div className='overflow-hidden'>
       <Banner/>
       <div>
         <div className='w-full text-3xl text-center p-5 m-4'>

--- a/src/components/Anime/AnimeCard.jsx
+++ b/src/components/Anime/AnimeCard.jsx
@@ -23,7 +23,7 @@ function AnimeCard({ image_url, title, handleAddToWatchList, animeObj, handleRem
         </div>)}
 
 
-      <div className='text-white w-full  text-center font-bold p-3 bg-gray-900/70'>
+      <div className='text-white w-full  text-center font-bold p-3 bg-gray-900/70 rounded-br-lg rounded-bl-lg'>
         {title}
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,25 @@
     font-style: normal;
 }
 
+/* vertical scrollbar styling */
+::-webkit-scrollbar{
+    width: 1px;
+}
+
+::-webkit-scrollbar-thumb{
+    background-color: #888;
+    border-radius: 5px;
+}
+
+::-webkit-scrollbar-thumb:hover{
+    background-color: #555;
+}
+
+/* vertical scrollbar for firefox */
+body {
+  scrollbar-width: none;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
**Type:** Enhancement

**Description:**
 - Styles the vertical scrollbar
 - hides the horizontal scrollbar
 - Fixes the bottom left and right corner radius of anime cards.
 
**Related Issue:**
   #27 

**Checklist:**
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes locally

**Screenshots**
- Before
<img width="9000" height="700" alt="Screenshot 2025-07-22 182602" src="https://github.com/user-attachments/assets/363f8503-08be-415f-8a0b-05aee0168e99" />

- After      
<img width="9000" height="700" alt="Screenshot 2025-07-22 235251" src="https://github.com/user-attachments/assets/ddd39b1e-df1b-49a1-9cc7-00b6f8a64f63" />


