### PR TITLE
Add loading spinner to Anime and WatchList components

### DIFF
--- a/src/components/Anime/Anime.jsx
+++ b/src/components/Anime/Anime.jsx
@@ -3,6 +3,8 @@ import Banner from "./Banner.jsx";
 import axios from "axios";
 import AnimeCard from "./AnimeCard.jsx";
 import Pagination from "../Pagination.jsx";
+import Spinner from "../Spinner.jsx";
+
 
 function Anime() {
   const [anime, setAnime] = useState([]);
@@ -10,6 +12,9 @@ function Anime() {
   const [watchList, setWatchList] = useState(
     JSON.parse(localStorage.getItem("watchlist")) || []
   );
+
+  const [loading, setLoading] = useState(true);
+
 
   const handleAddToWatchList = (animeObj) => {
     const newWatchList = [...watchList, animeObj];
@@ -40,6 +45,9 @@ function Anime() {
 
   useEffect(() => {
     async function fetchData() {
+
+          setLoading(true); // Start loading
+
       const api_URL = import.meta.env.VITE_API_URL;
 
       try {
@@ -48,11 +56,19 @@ function Anime() {
         // console.log(res.data)
       } catch (error) {
         console.error("Error fetching data:", error);
-      }
+      } 
+      finally {
+      setLoading(false); // Stop loading
+    }
     }
     fetchData();
     console.log(watchList);
   }, [pageNo]);
+
+  if (loading) 
+    {
+  return <Spinner />;
+     }
 
   return (
     <div>

--- a/src/components/Spinner.css
+++ b/src/components/Spinner.css
@@ -1,0 +1,24 @@
+.spinner-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  font-family: sans-serif;
+  color: #050d17;
+}
+
+.spinner {
+  border: 6px solid #f3f3f3;
+  border-top: 6px solid #6db2e7;
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/components/Spinner.jsx
+++ b/src/components/Spinner.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import "./Spinner.css";
+
+const Spinner = () => {
+  return (
+    <div className="spinner-container h-screen">
+      <div className="spinner" />
+      <p>Loading ...</p>
+    </div>
+  );
+};
+
+export default Spinner;

--- a/src/components/WatchList/WatchList.jsx
+++ b/src/components/WatchList/WatchList.jsx
@@ -1,18 +1,31 @@
 import React, { useEffect, useState } from "react";
 import { FaArrowUp } from "react-icons/fa";
 import { FaArrowDown } from "react-icons/fa";
+import Spinner from "../Spinner";
 
 function WatchList() {
   const [watchList, setWatchList] = useState([]);
   const [search, setSearch] = useState("");
   const [genreList, setGenreList] = useState(["All Genres"]);
   const [currGenre, setCurreGenre] = useState("All Genres");
+  const [loading, setLoading] = useState(true);
+  
 
   useEffect(() => {
-    if (!localStorage.getItem("watchlist")) {
-      return;
-    }
-    setWatchList(JSON.parse(localStorage.getItem("watchlist")));
+
+      setLoading(true);  //start loading
+
+        setTimeout(() => {
+          if (!localStorage.getItem("watchlist")) {
+           return;
+           } 
+          
+           setWatchList(JSON.parse(localStorage.getItem("watchlist")));
+       
+        setLoading(false); //stop loading
+
+        }, 200); // simulate 200ms delay to show spinner
+      
   }, []);
 
   const handleSearch = (e) => {
@@ -52,6 +65,11 @@ function WatchList() {
     temp = new Set(temp);
     setGenreList(["All Genres", ...temp]);
   }, [watchList]);
+
+  if (loading)     //if loading is true , return spinner.
+    {
+  return <Spinner />;
+    }
 
   return (
     <>


### PR DESCRIPTION
This PR adds a loading spinner to both the Anime and  WatchList components to improve the user experience while data is being fetched.

* Created a reusable Spinner component with basic styling.

* Added a loading state in Anime.jsx and displayed the spinner while fetching data from the API.

* In WatchList.jsx, added a small delay to simulate loading for consistency.

* Ensured the spinner is centered using Tailwind classes.

Let me know if any changes are needed — happy to adjust!

