### PR TITLE
fix: hide hero section when search query is active

### DIFF
--- a/src/components/Anime/Anime.jsx
+++ b/src/components/Anime/Anime.jsx
@@ -72,7 +72,7 @@ function Anime() {
 
   return (
     <div className='overflow-hidden'>
-      <Banner />
+      {!searchQuery && <Banner />}
       <div>
         <div className='w-full text-3xl text-center p-5 m-4'>
           {searchQuery ? `Search Results for "${searchQuery}"` : 'Trending Anime'}


### PR DESCRIPTION
## What is the change?

- Added logic to conditionally hide the banner section when search is active.
- Ensures a cleaner UI by preventing banner overlap with search results.

## Why this change is necessary?

- The banner remained visible during search, cluttering the UI and causing distraction.
- This fix improves focus and readability during search interaction.

## Before:
<img width="1919" height="1042" alt="Screenshot 2025-07-29 004720" src="https://github.com/user-attachments/assets/398c3250-5ee7-4ee2-a72e-2110552ece2c" />


## After:
<img width="1914" height="1032" alt="Screenshot 2025-07-29 003020" src="https://github.com/user-attachments/assets/276073f0-2ab4-4f70-b0b5-6161167bad0c" />


## Checklist:

- [x] Code compiles and runs without errors.
- [x] Follows the existing code style and structure.
- [x] Tested and verified locally.

Let me know if any additional refinements are needed!
