### PR TITLE
Fix scroll-to-top button

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -8,7 +8,6 @@ import {
   Instagram,
   ChevronUp,
   Heart,
-  ExternalLink,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 
@@ -49,7 +48,7 @@ function Footer() {
 
       {showScrollToTop && (
         <button
-          className="fixed bottom-6 right-6 bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-full shadow-lg"
+          className="fixed bottom-20 right-6 bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-full shadow-lg z-50"
           onClick={scrollToTop}
         >
           <ChevronUp />


### PR DESCRIPTION
**Type:** Bug #121
**Description:** The top-to-bottom Scroll button is no longer overlapping with footer icons
### Earlier :
<img width="1919" height="969" alt="image" src="https://github.com/user-attachments/assets/ee4e6844-b726-4602-9210-f9d2ab6fe6a9" />

### Fixed :
<img width="1911" height="905" alt="image" src="https://github.com/user-attachments/assets/e3494d3c-8263-4edd-84b3-05245ca4bd32" />

A brief description of what your PR does.
**Related Issue:** Issue #121
Link to the issue this PR addresses (if any).
**Checklist:**
- [✅ ] My code follows the code style of this project
- [✅ ] I have performed a self-review of my code
- [✅ ] I have commented my code, particularly in hard-to-understand areas
- [✅ ] I have made corresponding changes to the documentation (if needed)
- [✅ ] My changes generate no new warnings or errors
- [✅ ] I have tested my changes locally